### PR TITLE
feat: support for disabling models during upload process

### DIFF
--- a/src/Actions/Upload.php
+++ b/src/Actions/Upload.php
@@ -90,9 +90,7 @@ class Upload
     public static function enableFor(string|array|Model $models): void
     {
         if ($models instanceof Model) {
-            self::$disabledModels = collect(static::$disabledModels)->filter(function ($model) use ($models) {
-                return $model instanceof $models && $model->getKey() !== $models->getKey();
-            })->toArray();
+            self::$disabledModels = array_filter(self::$disabledModels, fn ($model) => ! $model instanceof $models || $model->getKey() !== $models->getKey());
         } else {
             self::$disabledModels = array_diff(self::$disabledModels, is_array($models) ? $models : [$models]);
         }

--- a/tests/ModelEventsTest.php
+++ b/tests/ModelEventsTest.php
@@ -81,6 +81,31 @@ it('should upload the file for the models that were previously added to the disa
     expect($anotherPost2->uploads()->count())->toBe(1);
 });
 
+it('should accept a model instance when disabling the upload process', function () {
+    create_request_with_files();
+    // Create a post silently so it won't have the uploads initially
+    $post = create_post(new TestPost(), silently: true);
+    ActionsUpload::disableFor($post);
+    $updatePost = update_post($post);
+    $anotherPost = create_post(new TestPost());
+
+    expect($updatePost->uploads()->count())->toBe(0);
+    expect($anotherPost->uploads()->count())->toBe(1);
+});
+
+it('should accept a model instance when enabling the upload process', function () {
+    create_request_with_files();
+    // Create a post silently so it won't have the uploads initially
+    $post = create_post(new TestPost(), silently: true);
+    ActionsUpload::disableFor(TestPost::class);
+    ActionsUpload::enableFor($post);
+    $updatePost = update_post($post);
+    $anotherPost = create_post(new TestPost());
+
+    expect($updatePost->uploads()->count())->toBe(1);
+    expect($anotherPost->uploads()->count())->toBe(1);
+});
+
 it('can upload a file with storage options, set from static', function () {
     create_request_with_files();
     TestPost::uploadStorageOptions([

--- a/tests/ModelEventsTest.php
+++ b/tests/ModelEventsTest.php
@@ -93,17 +93,44 @@ it('should accept a model instance when disabling the upload process', function 
     expect($anotherPost->uploads()->count())->toBe(1);
 });
 
+it('should only disable the upload for the specific model instance', function () {
+    create_request_with_files();
+    // Create a post silently so it won't have the uploads initially
+    $post1 = create_post(new TestPost(), silently: true);
+    $post2 = create_post(new TestPost(), silently: true);
+    ActionsUpload::disableFor($post1);
+    $updatePost1 = update_post($post1);
+    $updatePost2 = update_post($post2);
+
+    expect($updatePost1->uploads()->count())->toBe(0);
+    expect($updatePost2->uploads()->count())->toBe(1);
+});
+
 it('should accept a model instance when enabling the upload process', function () {
     create_request_with_files();
     // Create a post silently so it won't have the uploads initially
     $post = create_post(new TestPost(), silently: true);
-    ActionsUpload::disableFor(TestPost::class);
+    ActionsUpload::disableFor($post);
     ActionsUpload::enableFor($post);
     $updatePost = update_post($post);
     $anotherPost = create_post(new TestPost());
 
     expect($updatePost->uploads()->count())->toBe(1);
     expect($anotherPost->uploads()->count())->toBe(1);
+});
+
+it('should only enable the upload for the specific model instance', function () {
+    create_request_with_files();
+    // Create a post silently so it won't have the uploads initially
+    $post1 = create_post(new TestPost(), ['title' => 'Post 1'], silently: true);
+    $post2 = create_post(new TestPost(), ['title' => 'Post 2'], silently: true);
+    ActionsUpload::disableFor([$post1, $post2]);
+    ActionsUpload::enableFor($post1);
+    $updatePost1 = update_post($post1);
+    $updatePost2 = update_post($post2);
+
+    expect($updatePost1->uploads()->count())->toBe(1);
+    expect($updatePost2->uploads()->count())->toBe(0);
 });
 
 it('can upload a file with storage options, set from static', function () {

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -3,6 +3,7 @@
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
 use Illuminate\Http\UploadedFile;
+use NadLambino\Uploadable\Actions\Upload;
 use NadLambino\Uploadable\Tests\Models\TestPost;
 use NadLambino\Uploadable\Tests\Models\TestPostWithCustomStorageOptions;
 use NadLambino\Uploadable\Tests\TestCase;
@@ -28,6 +29,7 @@ function reset_config(): void
     TestPost::$uploadOnQueue = null;
     TestPost::$validateUploads = null;
     TestPostWithCustomStorageOptions::$uploadStorageOptions = null;
+    Upload::disableFor([]);
 }
 
 function create_post(?Model $model = null, array $attributes = [], bool $silently = false): Model


### PR DESCRIPTION
Potential Issue: When doing a create/update of multiple models that are implementing the uploadable package, the default behavior is that it will upload the files from the request to all of these models.

Fix: Add the ability to set a list of models that will be ignored during the upload process.

```php
use NadLambino\Uploadable\Actions\Upload;

public function store(Request $request)
{
    // Disable the uploads for all of the instances of Post model during this request lifecycle
    Upload::disableFor(Post::class);

    User::create($request->validated());
    Post::create(...);
}

// OR

public function update(Request $request, User $user)
{
     // Disable the uploads only for this specific user during this request lifecycle
    Upload::disableFor($user);

    $user->update($request->validated());
    
    $anotherUser = User::find(...);
    $anotherUser->update(...); // This will have the uploaded files
}
```