### PR TITLE
feat: add onlyFor method to specifically tell what model should have the upload

### DIFF
--- a/src/Dto/UploadOptions.php
+++ b/src/Dto/UploadOptions.php
@@ -25,6 +25,8 @@ class UploadOptions
 
     public readonly array $disabledModels;
 
+    public readonly array $onlyModels;
+
     public function __construct(
         public readonly ?SerializableClosure $beforeSavingUploadUsing = null,
         public readonly bool $disableUpload = false,
@@ -37,6 +39,7 @@ class UploadOptions
         $this->deleteModelOnQueueUploadFail = config('uploadable.delete_model_on_queue_upload_fail', false);
         $this->disabledModels = Upload::$disabledModels;
         $this->forceDeleteUploads = config('uploadable.force_delete_uploads', false);
+        $this->onlyModels = Upload::$onlyModels;
         $this->replacePreviousUploads ??= config('uploadable.replace_previous_uploads', false);
         $this->rollbackModelOnUploadFail = config('uploadable.rollback_model_on_upload_fail', true);
         $this->rollbackModelOnQueueUploadFail = config('uploadable.rollback_model_on_queue_upload_fail', false);

--- a/tests/ModelEventsTest.php
+++ b/tests/ModelEventsTest.php
@@ -133,6 +133,70 @@ it('should only enable the upload for the specific model instance', function () 
     expect($updatePost2->uploads()->count())->toBe(0);
 });
 
+it('should upload the file only for the given model class', function () {
+    create_request_with_files();
+    ActionsUpload::onlyFor(TestPostWithCustomFilename::class);
+    $post = create_post(new TestPost());
+    $anotherPost = create_post(new TestPostWithCustomFilename());
+
+    expect($post->uploads()->count())->toBe(0);
+    expect($anotherPost->uploads()->count())->toBe(1);
+});
+
+it('should upload the file only for the given model classes', function () {
+    create_request_with_files();
+    ActionsUpload::onlyFor([TestPostWithCustomFilename::class, TestPostWithCustomPath::class]);
+    $post = create_post(new TestPost());
+    $anotherPost = create_post(new TestPostWithCustomFilename());
+    $anotherPost2 = create_post(new TestPostWithCustomPath());
+
+    expect($post->uploads()->count())->toBe(0);
+    expect($anotherPost->uploads()->count())->toBe(1);
+    expect($anotherPost2->uploads()->count())->toBe(1);
+});
+
+it('should upload the file only for the given model instance', function () {
+    create_request_with_files();
+    // Create a post silently so it won't have the uploads initially
+    $post = create_post(new TestPost(), silently: true);
+    ActionsUpload::onlyFor($post);
+    $anotherPost = create_post(new TestPostWithCustomFilename());
+    $updatePost = update_post($post);
+
+    expect($updatePost->uploads()->count())->toBe(1);
+    expect($anotherPost->uploads()->count())->toBe(0);
+});
+
+it('should upload the file only for the given model instances', function () {
+    create_request_with_files();
+    // Create a post silently so it won't have the uploads initially
+    $post1 = create_post(new TestPost(), ['title' => 'Post 1'], silently: true);
+    $post2 = create_post(new TestPost(), ['title' => 'Post 2'], silently: true);
+    ActionsUpload::onlyFor([$post1, $post2]);
+    $updatePost1 = update_post($post1);
+    $updatePost2 = update_post($post2);
+    $post3 = create_post(new TestPost());
+
+    expect($updatePost1->uploads()->count())->toBe(1);
+    expect($updatePost2->uploads()->count())->toBe(1);
+    expect($post3->uploads()->count())->toBe(0);
+});
+
+it('should upload the file only for the given model instance and class', function () {
+    create_request_with_files();
+    // Create a post silently so it won't have the uploads initially
+    $post1 = create_post(new TestPost(), ['title' => 'Post 1'], silently: true);
+    $post2 = create_post(new TestPost(), ['title' => 'Post 2'], silently: true);
+    ActionsUpload::onlyFor([$post1, TestPostWithCustomFilename::class]);
+    $updatePost1 = update_post($post1);
+    $updatePost2 = update_post($post2);
+    $anotherPost = create_post(new TestPostWithCustomFilename());
+
+    expect($updatePost1->uploads()->count())->toBe(1);
+    expect($updatePost2->uploads()->count())->toBe(0);
+    expect($anotherPost->uploads()->count())->toBe(1);
+});
+
 it('can upload a file with storage options, set from static', function () {
     create_request_with_files();
     TestPost::uploadStorageOptions([

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -30,6 +30,7 @@ function reset_config(): void
     TestPost::$validateUploads = null;
     TestPostWithCustomStorageOptions::$uploadStorageOptions = null;
     Upload::disableFor([]);
+    Upload::onlyFor([]);
 }
 
 function create_post(?Model $model = null, array $attributes = [], bool $silently = false): Model


### PR DESCRIPTION
In events where you are creating or updating multiple models, you can instruct the `NadLambino\Uploadable\Actions\Upload` action to only process the file upload for the give model classes or instances

```php
use NadLambino\Uploadable\Actions\Upload;

public function store()
{
    Upload::onlyFor(User::class);

    // The files from the request will be uploaded and attached to this created user
    User::create(...);

    // The files from the request won't be uploaded and attached to this created post
    Post::create(...);
}

public function update(User $user)
{
    Upload::onlyFor($user);

    // This user will be updated and the files from the request will be uploaded and attached to it
    $user->update(...);

    $user2 = User::find(...);

    // This user will be updated but the files from the request won't be uploaded and attached to it
    $user2->update(...)
}
```

The `onlyFor` method can accept a single or an array of model classes and instances.